### PR TITLE
fix(coercion) - boolean string coercion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.7.x
+    - name: Build and test with Rake
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+        bundle exec rake

--- a/lib/shrink/wrap/metadata.rb
+++ b/lib/shrink/wrap/metadata.rb
@@ -40,7 +40,12 @@ module Shrink
           next if value.nil?
 
           coercion = coercions[property]
-          memo[property] = coercion&.coerce(value) || value
+
+          memo[property] = if coercion
+                             coercion.coerce(value)
+                           else
+                             value
+                           end
         end
       end
 

--- a/lib/shrink/wrap/version.rb
+++ b/lib/shrink/wrap/version.rb
@@ -2,6 +2,6 @@
 
 module Shrink
   module Wrap
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/shrink_wrap.gemspec
+++ b/shrink_wrap.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/shrink/wrap/metadata_spec.rb
+++ b/spec/shrink/wrap/metadata_spec.rb
@@ -48,14 +48,28 @@ describe Shrink::Wrap::Metadata do
   end
 
   describe 'coerce' do
-    let(:input) { { number: 1 } }
+    context 'with numbers' do
+      let(:input) { { number: 1 } }
 
-    before(:each) do
-      subject.add_coercion(:number, ->(v) { v + 1 })
+      before(:each) do
+        subject.add_coercion(:number, ->(v) { v + 1 })
+      end
+
+      it 'coerces the input' do
+        expect(subject.coerce(input)).to eq(number: 2)
+      end
     end
 
-    it 'coerces the input' do
-      expect(subject.coerce(input)).to eq(number: 2)
+    context 'when coercing strings to boolean' do
+      let(:input) { { boolean: 'false' } }
+
+      before(:each) do
+        subject.add_coercion(:boolean, ->(v) { v.to_s.casecmp('true').zero? })
+      end
+
+      it 'returns the coerced boolean value' do
+        expect(subject.coerce(input)).to eq(boolean: false)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'date'
 
 SimpleCov.start
 
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.include Helpers::Fixtures


### PR DESCRIPTION
* Previously a coercion that was defined as follows:
  ```ruby
  coerce(
    boolean: ->(v) { v.to_s.casecmp('true').zero? }
  )
  ```

  would incorrectly return the string `'false'` when given an input
  string of `'false'`. This was due to short-circuit evaluation.
* Fix the bug by using an explicit `if/else` block.
* Relax the restriction on bundler in the dev environment - there's
  no need to require a specific version.
* Bump version to 0.1.1.