### PR TITLE
feature: CollectionFromKey Primitive Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.2.0 - Apr 17, 2020
+
+* **breaking change**: Modify the `CollectionFromKey` transformer to map non-hash values into a hash with a `value` property.
+
+i.e. ```ruby
+input = { names: { john: 'foo', jane: 'bar' } }
+transformer.transform(input) #=>  { names: [{ name: :john, value: 'foo' }, { name: :jane, value: 'bar' }] }
+```
+
 # 0.1.0 - Dec. 2, 2018
 
 * Initial release! :sparkles:

--- a/lib/shrink/wrap/transformer/collection_from_key.rb
+++ b/lib/shrink/wrap/transformer/collection_from_key.rb
@@ -28,8 +28,11 @@ module Shrink
 
         def map(data, to)
           data.map do |key, value|
-            ensure_type!(Hash, value)
-            value.merge(to => key)
+            if value.is_a?(Hash)
+              value.merge(to => key)
+            else
+              { to => key, value: value }
+            end
           end
         end
 

--- a/lib/shrink/wrap/version.rb
+++ b/lib/shrink/wrap/version.rb
@@ -2,6 +2,6 @@
 
 module Shrink
   module Wrap
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end

--- a/spec/shrink/wrap/transformer/collection_from_key_spec.rb
+++ b/spec/shrink/wrap/transformer/collection_from_key_spec.rb
@@ -50,12 +50,21 @@ describe Shrink::Wrap::Transformer::CollectionFromKey do
 
         context 'when the from value is a hash' do
           context 'when the child elements are not hashes' do
-            let(:hash) { { names: { a: 1, b: 2 } } }
+            let(:hash) do
+              {
+                names: {
+                  one: 'test_one',
+                  two: 'test_two'
+                }
+              }
+            end
 
-            it 'raises ArgumentError' do
-              expect { subject.transform(hash) }.to raise_error(
-                ArgumentError,
-                'expected Hash, got: 1'
+            it 'returns an array with hash elements' do
+              expect(subject.transform(hash)).to eq(
+                names: [
+                  { name: :one, value: 'test_one' },
+                  { name: :two, value: 'test_two' }
+                ]
               )
             end
           end


### PR DESCRIPTION
* **breaking change**: Allow non-hash values in the `CollectionFromKey`
  transformer.
* Non-hash values are mapped into a hash element with a `value` key*
  present.
* Release version 0.2.0.