### PR TITLE
fix(stringio) - Fix StringIO Require

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,5 @@ Documentation:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+Style/IfUnlessModifier:
+  Enabled: false

--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 SimpleCov.start do
   SimpleCov.minimum_coverage 100.00
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0 - Oct 1, 2020
+
+* Explicity require `stringio` from the standard library as it is used for some error messages.
+
 # 0.2.0 - Apr 17, 2020
 
 * **breaking change**: Modify the `CollectionFromKey` transformer to map non-hash values into a hash with a `value` property.

--- a/lib/shrink/all.rb
+++ b/lib/shrink/all.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pp'
+require 'stringio'
 require_relative 'wrap/version'
 require_relative 'wrap/metadata'
 require_relative 'wrap/support/type_check'

--- a/lib/shrink/wrap/version.rb
+++ b/lib/shrink/wrap/version.rb
@@ -2,6 +2,6 @@
 
 module Shrink
   module Wrap
-    VERSION = '0.2.0'
+    VERSION = '1.0.0'
   end
 end

--- a/shrink_wrap.gemspec
+++ b/shrink_wrap.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
       .reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
* Explicitly require `stringio` from the standard library as it's
  used in error message generation.
* Release version 1.0.0!