### PR TITLE
fix(translation): Explicit Nil Property Values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
   DisplayCopNames: true
+  NewCops: enable
+  SuggestExtensions: false
   TargetRubyVersion: 2.5
   Exclude:
     - 'bin/**/*'
@@ -10,4 +12,6 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 Style/IfUnlessModifier:
+  Enabled: false
+Style/RedundantFetchBlock:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.5.1
-before_install: gem install bundler -v '~> 2.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1 - June 1, 2021
+
+* Translation properties that define a `default` option now correctly call resolve the default value when the input value is explicitly `nil`. See [#7](https://github.com/jessedoyle/shrink_wrap/pull/7).
+
 # 1.0.0 - Oct 1, 2020
 
 * Explicity require `stringio` from the standard library as it is used for some error messages.

--- a/lib/shrink/wrap/metadata.rb
+++ b/lib/shrink/wrap/metadata.rb
@@ -26,8 +26,8 @@ module Shrink
       def translate(data)
         return data if translate_all
 
-        translations.each_with_object({}) do |(key, translation), memo|
-          memo[key] = translation.translate(data)
+        translations.transform_values do |translation|
+          translation.translate(data)
         end
       end
 

--- a/lib/shrink/wrap/property/translation.rb
+++ b/lib/shrink/wrap/property/translation.rb
@@ -32,7 +32,7 @@ module Shrink
           return opts.fetch(from) { key_error!(opts) } if default.nil?
 
           ensure_callable!(default, 0)
-          opts.fetch(from) { default.call }
+          opts[from] || default.call
         end
 
         def key_error!(opts)

--- a/lib/shrink/wrap/transformer/symbolize.rb
+++ b/lib/shrink/wrap/transformer/symbolize.rb
@@ -12,6 +12,7 @@ module Shrink
 
         private
 
+        # rubocop:disable Style/OptionalBooleanParameter
         def symbolize(element, depth, symbolize_singular = false)
           return element if depth > options.fetch(:depth) { DEFAULT_DEPTH }
 
@@ -24,6 +25,7 @@ module Shrink
             symbolize_singular ? to_sym(element) : element
           end
         end
+        # rubocop:enable Style/OptionalBooleanParameter
 
         def symbolize_enumerable(array, depth)
           array.map { |i| symbolize(i, depth) }

--- a/lib/shrink/wrap/version.rb
+++ b/lib/shrink/wrap/version.rb
@@ -2,6 +2,6 @@
 
 module Shrink
   module Wrap
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/spec/shrink/wrap/property/translation_spec.rb
+++ b/spec/shrink/wrap/property/translation_spec.rb
@@ -64,6 +64,15 @@ describe Shrink::Wrap::Property::Translation do
               expect(subject.translate(input)).to eq(default.call)
             end
           end
+
+          context 'when the value is nil' do
+            let(:default) { -> { true } }
+            let(:input) { { key: nil } }
+
+            it 'returns the default value' do
+              expect(subject.translate(input)).to eq(default.call)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Previously the default callable option on a property translation
would not correctly resolve a value when the input hash value was
nil.

i.e.

```ruby
class MyClass
  include Shrink::Wrap
  transform(Shrink::Wrap::Transformer::Symbolize)
  translate(
    name: { from: :name, allow_nil: false, default: -> { 'jane'  }
  )
end
instance = MyClass.shrink_wrap(name: nil)
instance.name.nil? # => true
```

Fix the default resolution logic to lazily evaluate when the
hash value is explicitly `nil`. This will make the `instance.name`
value from the example above correctly return `'jane'`.