### PR TITLE
chore: Release Version 1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.x
-    - name: Build and test with Rake
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        bundle exec rake
+        ruby-version: '3.2'
+        bundler-cache: true
+    - name: Run Specs
+      run: bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,11 @@ AllCops:
     - 'vendor/**/*'
 Documentation:
   Enabled: false
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+Lint/RedundantRequireStatement:
+  Exclude:
+    - lib/shrink/all.rb
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.2 - Feb 3, 2023
+
+* Fix an issue with the `shrink_wrap` require statement. [#8], Thanks @mvandenbeuken!
+
 # 1.0.1 - June 1, 2021
 
 * Translation properties that define a `default` option now correctly call resolve the default value when the input value is explicitly `nil`. See [#7](https://github.com/jessedoyle/shrink_wrap/pull/7).

--- a/shrink_wrap.gemspec
+++ b/shrink_wrap.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.authors = ['Jesse Doyle']
   spec.email = ['jdoyle@ualberta.ca']
   spec.summary = 'Transform complex JSON data into custom Ruby objects'
-  spec.description = 'Shrink::Wrap is a dead-simple framework to manipulate' \
-                     ' and map JSON data to Ruby object instances.'
+  spec.description = 'Shrink::Wrap is a dead-simple framework to manipulate ' \
+                     'and map JSON data to Ruby object instances.'
   spec.homepage = 'https://github.com/jessedoyle/shrink_wrap'
   spec.license = 'MIT'
 
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
* Update changelog with an entry for version 3.0.2
* Fix CI by moving to the `ruby/setup-ruby` action and test against the current latest ruby version (3.2.X).

see: https://github.com/jessedoyle/shrink_wrap/pull/8